### PR TITLE
Add Windows support, fix S3 being used by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ For self-hosting instructions, keep reading the README. 👇
 - [Docker](https://docs.docker.com/get-docker/) installed
 - NVIDIA GPU with at least 12GB of VRAM (with a batch size of 1)
 - NVIDIA drivers installed + [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker) installed
-- Linux based OS
-> Please Windows users, go dual-boot, unfortunatly I don't have any experience with Windows and Docker.
 
 ## Installation
 
@@ -104,19 +102,22 @@ docker images
 docker run -d \
   --gpus all \
   --network picaisso \
-  -p 7680:7680 \
+  -p 7681:7681 \
   -v ${HOME}/.cache:/root/.cache \
   --restart unless-stopped \
   --name picaisso-api \
   picaisso-api:latest
 ```
+<!--
+docker run -d --gpus all --network picaisso -p 7681:7681 -v ~/.cache:/root/.cache --restart unless-stopped --name picaisso-api picaisso-api:latest
+-->
 
 3. Test the API
 
-The API should be running on port `7680` of your machine. It can take a few minutes to start, because the model has
-to be downloaded and loaded on the first run. Because we are using the `${HOME}/.cache`folder as a mounted volume, the model will be downloaded only once and will be reused on the next runs.
+The API should be running on port `7681` of your machine. It can take a few minutes to start, because the model has
+to be downloaded and loaded on the first run. Because we are using the `${HOME}/.cache` folder as a mounted volume, the model will be downloaded only once and will be reused on the next runs.
 
-Once the API is running, you can test it by going to `http://localhost:7680/` in your web browser.
+Once the API is running, you can test it by going to `http://localhost:7681/` in your web browser.
 
 You should see the landing page of the API.
 
@@ -143,9 +144,19 @@ docker run -d \
   --name picaisso-bot \
   picaisso-bot:latest
 ```
+<!--
+docker run -d --restart unless-stopped --network picaisso --name picaisso-bot picaisso-bot:latest
+-->
 
 If you successfully created the Discord bot application, you just need to invite it to your server. You can find the invite link in the `OAuth2` section of your Discord bot application.
 (See the tutorial link in the `.env.template` file.)
+
+<!--
+Which scopes does the bot need?
+-->
+
+Note: Server Members Intent must be enabled on the Discord bot (under the `Bot` section):
+![server-members-intent](https://user-images.githubusercontent.com/37621491/236005728-8469f159-98e9-4082-bfc7-772da5d7cacd.png)
 
 Mine is live! 🎉
 
@@ -162,7 +173,7 @@ You can use the project in three different ways:
 ### API documentation
 
 For testing purposes, you can use the API documentation to generate images and validate everything is working 
-as expected. You can find the API documentation at `http://localhost:7680/docs` when the API is running.
+as expected. You can find the API documentation at `http://localhost:7681/docs` when the API is running.
 
 ![api-docs-1](assets/api-docs-1.png)
 

--- a/config/api/.env.template
+++ b/config/api/.env.template
@@ -59,15 +59,15 @@ N_STEPS=50
 #
 # The bucket name is the name of the S3 bucket where the images will be stored. Leave it empty if you don't want to use
 # an external S3 bucket for image storage.
-BUCKET_NAME=None
+BUCKET_NAME=
 # The region name is the name of the region where the S3 bucket is located. Leave it empty if you don't want to use
 # an external S3 bucket for image storage.
-REGION_NAME=None
+REGION_NAME=
 # The access key id is the access key id of the S3 bucket. Leave it empty if you don't want to use an external S3 bucket
 # for image storage.
-ACCESS_KEY_ID=None
+ACCESS_KEY_ID=
 # The secret access key is the secret access key of the S3 bucket. Leave it empty if you don't want to use an external
 # S3 bucket for image storage.
-SECRET_ACCESS_KEY=None
+SECRET_ACCESS_KEY=
 #
 # -------------------------------------------------------------------------------------------------------------------- #

--- a/config/bot/.env.template
+++ b/config/bot/.env.template
@@ -21,6 +21,8 @@ DISCORD_TOKEN=1234567890abcdef  # <-- CHANGE ME
 # It should include the root path and the api prefix.
 # Change it if you modify the container name, the port, the prefix or if the API server is running behind a 
 # reverse proxy with a dns name.
-API_URL="http://picaisso-api:7680/api/v1"  # <-- CHANGE ME
+API_URL="http://picaisso-api:7681/api/v1"  # <-- CHANGE ME
+# If you're deploying locally and on Windows, you may want to use 'host.docker.internal' rather than 'localhost'
+# API_URL="http://host.docker.internal:7681/api/v1"
 #
 # -------------------------------------------------------------------------------------------------------------------- #

--- a/picaisso/api/config.py
+++ b/picaisso/api/config.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2023, Thomas Chaigneau. All rights reserved.
 
 from os import getenv
-from dotenv import load_dotenv
-from loguru import logger
 from typing import Optional, Union
 
+from dotenv import load_dotenv
+from loguru import logger
 from pydantic import Field, validator
 from pydantic.dataclasses import dataclass
 

--- a/picaisso/api/config.py
+++ b/picaisso/api/config.py
@@ -73,7 +73,7 @@ class Settings:
     def __post_init__(self):
         """Post init hook."""
         self.using_s3 = all([self.bucket_name, self.region_name, self.access_key_id, self.secret_access_key])
-        
+
         if self.using_s3:
             logger.warning("S3 credentials are set, the S3 storage will be used.")
         else:
@@ -86,8 +86,7 @@ settings = Settings(
     project_name=getenv("PROJECT_NAME", "PicAIsso"),
     version=getenv("VERSION", "1.0.0"),
     description=getenv(
-        "DESCRIPTION",
-        "🎨 Imagine what Picasso could have done with AI. Self-host your StableDiffusion API."
+        "DESCRIPTION", "🎨 Imagine what Picasso could have done with AI. Self-host your StableDiffusion API."
     ),
     api_prefix=getenv("API_PREFIX", "/api/v1"),
     debug=getenv("DEBUG", True),

--- a/picaisso/api/config.py
+++ b/picaisso/api/config.py
@@ -5,10 +5,12 @@ from dotenv import load_dotenv
 from loguru import logger
 from typing import Optional, Union
 
-from pydantic import BaseSettings, Field, validator
+from pydantic import Field, validator
+from pydantic.dataclasses import dataclass
 
 
-class Settings(BaseSettings):
+@dataclass
+class Settings:
     # General Configuration
     project_name: str
     version: str
@@ -31,7 +33,7 @@ class Settings(BaseSettings):
     region_name: Optional[str] = None
     access_key_id: Optional[str] = None
     secret_access_key: Optional[str] = None
-    _using_s3: bool = Field(init=False)
+    using_s3: bool = Field(init=False)
 
     @validator("username", "password", "openssl_key", "algorithm")
     def authentication_parameters_must_not_be_none(cls, value: str, field: str):
@@ -70,11 +72,9 @@ class Settings(BaseSettings):
 
     def __post_init__(self):
         """Post init hook."""
-        self._using_s3 = False if not all(
-            [self.bucket_name, self.region_name, self.access_key_id, self.secret_access_key]
-        ) else True
+        self.using_s3 = all([self.bucket_name, self.region_name, self.access_key_id, self.secret_access_key])
         
-        if self._using_s3:
+        if self.using_s3:
             logger.warning("S3 credentials are set, the S3 storage will be used.")
         else:
             logger.warning("S3 credentials are not set, the S3 storage will not be used.")

--- a/picaisso/api/dependencies.py
+++ b/picaisso/api/dependencies.py
@@ -1,18 +1,16 @@
 # Copyright (c) 2023, Thomas Chaigneau. All rights reserved.
 
 from datetime import datetime, timedelta
-from loguru import logger
 from typing import Union
 
 from fastapi import Depends, HTTPException
 from fastapi import status as http_status
 from fastapi.security import OAuth2PasswordBearer
-
 from jose import JWTError, jwt
-
-from config import settings
+from loguru import logger
 from models import TokenData
 
+from config import settings
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl=f"{settings.api_prefix}/auth")
 

--- a/picaisso/api/dependencies.py
+++ b/picaisso/api/dependencies.py
@@ -24,13 +24,13 @@ def _get_username() -> str:
 def create_access_token(data: dict, expires_delta: Union[timedelta, None] = None) -> str:
     """Create access token for user"""
     to_encode = data.copy()
-    
+
     if expires_delta:
         expire = datetime.utcnow() + expires_delta
-    else :
+    else:
         expire = datetime.utcnow() + timedelta(minutes=30)
     to_encode.update({"exp": expire})
-    
+
     return jwt.encode(to_encode, settings.openssl_key, algorithm=settings.algorithm)
 
 
@@ -65,16 +65,14 @@ async def get_current_user(
 async def authenticate_user(username: str, password: str) -> dict:
     """Authenticate user"""
     if username != settings.username or password != settings.password:
-        
+
         raise HTTPException(
             status_code=http_status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
             headers={"WWW-Authenticate": "Bearer"},
         )
     access_token_expires = timedelta(minutes=1440)
-    access_token = create_access_token(
-        data={"sub": username}, expires_delta=access_token_expires
-    )
+    access_token = create_access_token(data={"sub": username}, expires_delta=access_token_expires)
     logger.debug(f"Generate access token!")
-    
+
     return {"access_token": access_token, "token_type": "bearer"}

--- a/picaisso/api/diffusion_model.py
+++ b/picaisso/api/diffusion_model.py
@@ -11,12 +11,13 @@ import tomesd
 
 import torch
 from torch import autocast
+
 # Torch optimizations for inference
 torch.backends.cudnn.benchmark = True
 torch.backends.cuda.matmul.allow_tf32 = True
 
 
-class DiffusionService():
+class DiffusionService:
     def __init__(self, model_name: str, dtype: str, n_steps: int, max_batch_size: int, max_wait: int):
         self.model = model_name
         self.dtype = torch.float32 if dtype == "fp32" else torch.float16
@@ -24,19 +25,17 @@ class DiffusionService():
         self.max_batch_size = max_batch_size
         self.max_wait = max_wait
 
-        
         # Multi requests support
         self.queue = []
         self.queue_lock = None
         self.needs_processing = None
         self.needs_processing_timer = None
-        
+
         assert torch.cuda.is_available(), "CUDA is not available"
         self.pipeline = StableDiffusionPipeline.from_pretrained(self.model, torch_dtype=self.dtype)
         self.pipeline.to("cuda:0")
         tomesd.apply_patch(self.pipeline, ratio=0.5)
-    
-    
+
     def schedule_processing_if_needed(self):
         if len(self.queue) >= self.max_batch_size:
             self.needs_processing.set()
@@ -44,8 +43,7 @@ class DiffusionService():
             self.needs_processing_timer = asyncio.get_event_loop().call_at(
                 self.queue[0]["time"] + self.max_wait, self.needs_processing.set
             )
-            
-    
+
     async def process_input(self, prompt: str) -> str:
         """Process the input and return the result."""
         our_task = {
@@ -56,11 +54,10 @@ class DiffusionService():
         async with self.queue_lock:
             self.queue.append(our_task)
             self.schedule_processing_if_needed()
-            
+
         await our_task["done_event"].wait()
         return our_task["result"]
-    
-    
+
     async def runner(self):
         """Process the queue."""
         self.queue_lock = asyncio.Lock()
@@ -71,28 +68,25 @@ class DiffusionService():
             if self.needs_processing_timer is not None:
                 self.needs_processing_timer.cancel()
                 self.needs_processing_timer = None
-                
+
             async with self.queue_lock:
                 if self.queue:
                     longest_wait = asyncio.get_event_loop().time() - self.queue[0]["time"]
                 else:
                     longest_wait = None
-                prompt_batch = self.queue[:self.max_batch_size]
-                del self.queue[:self.max_batch_size]
+                prompt_batch = self.queue[: self.max_batch_size]
+                del self.queue[: self.max_batch_size]
                 self.schedule_processing_if_needed()
-                
+
             try:
                 batch = [prompt["prompt"] for prompt in prompt_batch]
-                results = await asyncio.get_event_loop().run_in_executor(
-                    None, functools.partial(self.inference, batch)
-                )
+                results = await asyncio.get_event_loop().run_in_executor(None, functools.partial(self.inference, batch))
                 for task, result in zip(prompt_batch, results.images):
                     task["result"] = result
                     task["done_event"].set()
                 del prompt_batch
             except Exception as e:
                 logger.error(e)
-
 
     def inference(self, prompt: str, n_samples: int = 1) -> np.ndarray:
         with autocast("cuda"):

--- a/picaisso/api/diffusion_model.py
+++ b/picaisso/api/diffusion_model.py
@@ -2,14 +2,12 @@
 
 import asyncio
 import functools
+
 import numpy as np
-from loguru import logger
-
-from diffusers import StableDiffusionPipeline
-
 import tomesd
-
 import torch
+from diffusers import StableDiffusionPipeline
+from loguru import logger
 from torch import autocast
 
 # Torch optimizations for inference

--- a/picaisso/api/main.py
+++ b/picaisso/api/main.py
@@ -2,20 +2,19 @@
 
 import asyncio
 import io
-from loguru import logger
-from PIL import Image
 
-from fastapi import BackgroundTasks, FastAPI, Depends, HTTPException
-from fastapi.responses import HTMLResponse, Response
-from fastapi import status as http_status
-from fastapi.security import OAuth2PasswordRequestForm
-
-from config import settings
-from dependencies import get_current_user, authenticate_user
+from dependencies import authenticate_user, get_current_user
 from diffusion_model import DiffusionService
+from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException
+from fastapi import status as http_status
+from fastapi.responses import HTMLResponse, Response
+from fastapi.security import OAuth2PasswordRequestForm
+from loguru import logger
 from models import ArtCreate, SignedUrl, Token
+from PIL import Image
 from utils import upload_image
 
+from config import settings
 
 app = FastAPI(
     title=settings.project_name,

--- a/picaisso/api/main.py
+++ b/picaisso/api/main.py
@@ -72,7 +72,7 @@ async def health_check():
     f"{settings.api_prefix}/generate",
     tags=["generate"],
     response_model=SignedUrl,
-    status_code=http_status.HTTP_200_OK
+    status_code=http_status.HTTP_200_OK,
 )
 async def generate(
     data: ArtCreate,
@@ -87,11 +87,16 @@ async def generate(
 
     if settings.using_s3:
         background_tasks.add_task(upload_image, img_bytes, data)
-    
-    return Response(content=img_bytes, media_type="image/jpeg")
-    
 
-@app.post(f"{settings.api_prefix}/auth", response_model=Token, tags=["authentication"], status_code=http_status.HTTP_200_OK)
+    return Response(content=img_bytes, media_type="image/jpeg")
+
+
+@app.post(
+    f"{settings.api_prefix}/auth",
+    response_model=Token,
+    tags=["authentication"],
+    status_code=http_status.HTTP_200_OK,
+)
 async def authentication(
     form_data: OAuth2PasswordRequestForm = Depends(),
 ):
@@ -107,6 +112,7 @@ async def authentication(
 
     logger.debug(f"Authenticating user {form_data.username}")
     return user
+
 
 if __name__ == "__main__":
     import uvicorn

--- a/picaisso/api/main.py
+++ b/picaisso/api/main.py
@@ -111,4 +111,4 @@ async def authentication(
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run("main:app", host="0.0.0.0", port=7680, reload=True)
+    uvicorn.run("main:app", host="0.0.0.0", port=7681, reload=True)

--- a/picaisso/api/main.py
+++ b/picaisso/api/main.py
@@ -85,7 +85,7 @@ async def generate(
         img_bytes = img_to_send.save(buffer, format="JPEG")
         img_bytes = buffer.getvalue()
 
-    if settings._using_s3:
+    if settings.using_s3:
         background_tasks.add_task(upload_image, img_bytes, data)
     
     return Response(content=img_bytes, media_type="image/jpeg")

--- a/picaisso/api/models.py
+++ b/picaisso/api/models.py
@@ -5,26 +5,31 @@ from pydantic import BaseModel
 
 class ArtCreate(BaseModel):
     """ArtCreate model"""
+
     prompt: str
     author: str
 
 
 class Image(BaseModel):
     """Image model"""
+
     content: bytes
-    
+
 
 class SignedUrl(BaseModel):
     """SignedUrl model"""
+
     url: str
 
 
 class Token(BaseModel):
     """Token model"""
+
     access_token: str
     token_type: str
-    
+
 
 class TokenData(BaseModel):
     """TokenData model"""
+
     username: str = None

--- a/picaisso/api/utils.py
+++ b/picaisso/api/utils.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2023, Thomas Chaigneau. All rights reserved.
 
 import uuid
+
 from aiobotocore.session import get_session
+from models import ArtCreate
 
 from config import settings
-from models import ArtCreate
 
 
 async def upload_image(img_bytes: bytes, data: ArtCreate):

--- a/picaisso/api/utils.py
+++ b/picaisso/api/utils.py
@@ -13,7 +13,7 @@ async def upload_image(img_bytes: bytes, data: ArtCreate):
         "s3",
         region_name=settings.region_name,
         aws_access_key_id=settings.access_key_id,
-        aws_secret_access_key=settings.secret_access_key
+        aws_secret_access_key=settings.secret_access_key,
     ) as client:
         img_key = f"{data.author}/{uuid.uuid4()}_{data.prompt}.jpg"
         await client.put_object(

--- a/picaisso/bot/main.py
+++ b/picaisso/bot/main.py
@@ -4,14 +4,14 @@ import asyncio
 import io
 import json
 import os
-from aiohttp import ClientSession
-from dotenv import load_dotenv
-from loguru import logger
 from typing import Optional
 
 import discord
+from aiohttp import ClientSession
 from discord import app_commands
 from discord.ext import commands
+from dotenv import load_dotenv
+from loguru import logger
 
 
 class OpenjourneyBot(discord.Client):

--- a/picaisso/bot/main.py
+++ b/picaisso/bot/main.py
@@ -24,17 +24,15 @@ class OpenjourneyBot(discord.Client):
         if intents is None:
             intents = discord.Intents.default()
         intents.members = True
-        
+
         super().__init__(intents=intents)
         self.web_client = web_client
         self.tree = app_commands.CommandTree(self)
-        
-    
+
     async def on_ready(self) -> None:
         """When the bot is ready."""
         await self.wait_until_ready()
         logger.debug(f"Logged in as {self.user}")
-
 
     async def on_guild_join(self, guild: discord.Guild) -> None:
         """
@@ -44,35 +42,34 @@ class OpenjourneyBot(discord.Client):
             guild (discord.Guild): The guild that the bot joined.
         """
         await self.tree.sync(guild=guild)
-        
-    
+
     async def _authenticate(self) -> None:
         """Authenticate with the API."""
         async with self.web_client.post(
             f"{os.getenv('API_URL')}/auth",
             headers={
                 "Content-Type": "application/json",
-                "Content-Type": "application/x-www-form-urlencoded"
+                "Content-Type": "application/x-www-form-urlencoded",
             },
             data={
                 "username": os.getenv("USERNAME"),
-                "password": os.getenv("PASSWORD")
+                "password": os.getenv("PASSWORD"),
             },
         ) as response:
             data = await response.json()
-            self.web_client.headers.update({
-                "accept": "application/json",
-                "Content-Type": "application/json",
-                "Authorization": f"Bearer {data['access_token']}",
-            })
-        
-    
+            self.web_client.headers.update(
+                {
+                    "accept": "application/json",
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {data['access_token']}",
+                }
+            )
+
     async def setup_hook(self) -> None:
         """Setup the bot at startup."""
         await self._authenticate()
         self.tree.add_command(art)
         await self.tree.sync()
-
 
     async def generate_art(self, interaction: discord.Interaction, prompt: str) -> None:
         """
@@ -129,10 +126,10 @@ async def art(interaction: discord.Interaction, prompt: str) -> None:
         interaction.client.loop.create_task(interaction.client.generate_art(interaction, prompt))
     else:
         await interaction.response.send_message("Please provide a prompt")
-  
-   
+
+
 async def main():
-    """Main loop."""""
+    """Main loop.""" ""
     async with ClientSession() as session:
         async with OpenjourneyBot(commands.when_mentioned, web_client=session) as client:
             await client.start(os.getenv("DISCORD_TOKEN"))


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add Windows support
  * Uses port 7681 instead of 7680. The latter is in use on Windows.
* Replace `BaseSettings` with pydantic `dataclass`
* Use empty instead of None as S3 defaults.
* Use black/isort for formatting.

As this PR makes various mostly unrelated changes, I would recommend reviewing the commits separately.

# Details
## Windows support (cc4499e407a97015726540dfb4594902d5b85246)
The [7680 port](https://www.speedguide.net/port.php?port=7680) is already used on Windows, causing problems when running the docker. As a result, a different port needs to be used for Windows.

I also added a message that `Server Members Intent` needs to be enabled. I got a semi-confusing error when it wasn't.

Also, on Windows you can't just connect to `localhost` from the bot docker when running both images locally. Instead, you need to use 'host.docker.internal'. ([docs](https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host))

## Replace `BaseSettings` with pydantic `dataclass` (f038d0d562cb995d206423db14dce5e62895b818)
The `__post_init__` wasn't being called for me. As a result, I didn't get logging about whether S3 was being used, and it ended up trying to upload to S3 using "None" in the URL. So, I replaced BaseSettings (which will be deprecated in v2.0 of pydantic) with a pydantic dataclass, which always supports `__post_init__`.

I also renamed `_using_s3` to `using_s3` as dataclass fields shouldn't start with underscores apparently.

## Use empty instead of None for S3 config (e53cc60f4eea25bf2a4b14a26e36e17e5499dd95)
With None everywhere, I get the following logs still:
```
S3 credentials are set, the S3 storage will be used.
```
After this change, I get this using the default config:
```
S3 credentials are not set, the S3 storage will not be used.
```
Which is intended.

## Ran formatters (black, isort) (1730a25354c52711e62b068e79716ebd7381b9bf, ebd0853ac3a4ffe465f0f909710c89ffd72f1d00)
Should speak for itself.

---

I recognize that this PR is a bit of a mess of various changes, so feel free to let me know if you want me to separate this PR or something.

After all of these changes, I'm able to run the bot on my own server 🎉 
![image](https://user-images.githubusercontent.com/37621491/236017770-c5e460b9-de5f-4674-938c-21e0388c3bb6.png)

Ignore the corny name of my Bot 🍅 

- Tom Aarsen