### PR TITLE
Allow bfloat16 dtype alongside fp32/fp16

### DIFF
--- a/config/api/.env.template
+++ b/config/api/.env.template
@@ -45,9 +45,9 @@ MAX_WAIT=0.5
 # Face Hub, by filtering the models with the "text-to-image" tag.
 # Check here: https://huggingface.co/models?pipeline_tag=text-to-image
 MODEL_NAME="prompthero/openjourney-v4"
-# The model precision is the precision of the model. You can choose between "fp32" and "fp16".
+# The model precision is the precision of the model. You can choose between "fp32", "fp16" and "bf16".
 # "fp32" is the default precision, but it's slower than "fp16". If you have a GPU with Tensor Cores, you should use
-# "fp16" for better performance.
+# "fp16" for better performance. With a sufficiently new GPU, you can also use "bf16".
 MODEL_PRECISION="fp16"
 # The number of steps is the number of steps of diffusion that the model will use to generate the image. The higher the
 # number of steps, the more detailed the image will be. But it will also take more time to generate the image. You 

--- a/picaisso/api/config.py
+++ b/picaisso/api/config.py
@@ -66,8 +66,8 @@ class Settings:
     @validator("model_precision")
     def model_precision_must_be_valid(cls, value: str):
         """Check that the model precision is valid."""
-        if value not in ["fp16", "fp32"]:
-            raise ValueError("model_precision must be either `fp16` or `fp32`.")
+        if value not in {"fp16", "fp32", "bf16"}:
+            raise ValueError("model_precision must be either `fp16`, `fp32` or `bf16`.")
         return value
 
     def __post_init__(self):

--- a/picaisso/api/diffusion_model.py
+++ b/picaisso/api/diffusion_model.py
@@ -18,7 +18,11 @@ torch.backends.cuda.matmul.allow_tf32 = True
 class DiffusionService:
     def __init__(self, model_name: str, dtype: str, n_steps: int, max_batch_size: int, max_wait: int):
         self.model = model_name
-        self.dtype = torch.float32 if dtype == "fp32" else torch.float16
+        self.dtype = {
+            "fp32": torch.float32,
+            "fp16": torch.float16,
+            "bf16": torch.bfloat16
+        }[dtype]
         self.n_steps = n_steps
         self.max_batch_size = max_batch_size
         self.max_wait = max_wait


### PR DESCRIPTION
Hello!

## Pull Request overview
* Allow `bf16` dtype alongside `fp16`/`fp32`.

## Details
Not all GPUs support it, but bf16 tends to be preferable over fp16 in what I've read. Although perhaps that's only for training, and then this PR can just be closed.

- Tom Aarsen